### PR TITLE
Add --no-verify option to bypass git hooks run

### DIFF
--- a/.github/workflows/update-config-files.yml
+++ b/.github/workflows/update-config-files.yml
@@ -107,8 +107,8 @@ jobs:
         working-directory: ./target
         run: |
           git add .
-          git commit -m "Update configuration files"
-          git push origin ${{inputs.head-pr-branch}} -f
+          git commit -m "Update configuration files" --no-verify
+          git push origin ${{inputs.head-pr-branch}} -f --no-verify
 
       - name: Check PR existence
         if: ${{ steps.successful-update.outputs.STATUS == 'true' }}


### PR DESCRIPTION
**Description:**
As some of the repos can use git hooks, this may break the workflow run (git hook can return non-zero exit code, e.g. [recent  run in setup-dotnet](https://github.com/actions/setup-dotnet/actions/runs/5055108311/jobs/9070922143)). I suggest to bypass git hooks in this workflow.

**Changes**
-  `--no-verify` option was added to `git commit`  and `git push` command to prevent runs of `pre-commit` and `pre-push` git hooks.


**Related workflow runs:**
- Initial failed run:
https://github.com/actions/setup-dotnet/actions/runs/5055108311/jobs/9070922143
- Runs with bypassed git hooks:
https://github.com/akv-platform/setup-dotnet/actions/runs/5055342488/jobs/9071426254
https://github.com/akv-platform/setup-node/actions/runs/5055414730/jobs/9071625020

