### PR TITLE
Update node version in workflows to node20

### DIFF
--- a/.github/workflows/basic-validation.yml
+++ b/.github/workflows/basic-validation.yml
@@ -24,7 +24,7 @@ on:
         description: "Optional input to set the version of Node.js used to build the project. The input syntax corresponds to the setup-node's one"
         required: false
         type: string
-        default: "16.x"
+        default: "20.x"
       node-caching:
         description: "Optional input to set up caching for the setup-node action. The input syntax corresponds to the setup-node's one. Set to an empty string if caching isn't needed"
         required: false

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -16,7 +16,7 @@ on:
         description: "Optional input to set the version of Node.js used to build a project. The input syntax corresponds to the setup-node's one"
         required: false
         type: string
-        default: "16.x"
+        default: "20.x"
       node-caching:
         description: "Optional input to set up caching for the setup-node action. The input syntax corresponds to the setup-node's one. Set to an empty string if caching isn't needed"
         required: false

--- a/.github/workflows/update-config-files.yml
+++ b/.github/workflows/update-config-files.yml
@@ -86,7 +86,7 @@ jobs:
         if: ${{ steps.successful-update.outputs.STATUS == 'true' }}
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
 
       - name: Install dependencies
         if: ${{ steps.successful-update.outputs.STATUS == 'true' }}


### PR DESCRIPTION
Node 16 has reached end-of-life on 11 Sep 202.
This PR updates the default runtime to node20, rather then node16.

This is supported on all Actions Runners v2.308.0 or later.