### PR TITLE
Fix for CodeQL analysis workflow failures

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,7 +11,7 @@ on:
         description: "Optional input to set languages for CodeQL check. Supported values are: 'cpp', 'csharp', 'go', 'java', 'javascript', 'typescript', 'python', 'ruby'. To set multiple languages, use the same syntax as you can see in the default value."
         required: false
         type: string
-        default: "['javascript']"
+        default: '["javascript"]'
       codeql-cfg-path:
         description: "Optional input to set path to a CodeQL config file"
         required: false


### PR DESCRIPTION
This PR will resolve the CodeQL analysis failures in setup-actions repositories.

This change modifies the default value for the languages input in the CodeQL check step. Previously, the value was set to default: "['javascript']". However, this format causes a parsing error because JSON requires double quotes (") for strings. The updated line default: '["javascript"]' fixes this issue by using double quotes for the array values, as required by JSON.