### PR TITLE
Add github-token to avoid CI failures due to rate limit

### DIFF
--- a/.github/workflows/basic-validation.yml
+++ b/.github/workflows/basic-validation.yml
@@ -62,6 +62,8 @@ jobs:
 
     - name: Test
       run: npm test
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
 
     - name: Audit packages
       run: npm audit --audit-level=high


### PR DESCRIPTION
When I triggered CI, it failed:

https://github.com/check-spelling-sandbox/setup-java/actions/runs/12417595625/job/34668910196

```js
FAIL __tests__/distributors/graalvm-installer.test.ts
  ● findPackageForDownload › version is 24-ea -> /^https:\/\/github\.com\/graalvm\/oracle-graalvm-ea-builds\/releases\/download\/jdk-24\.0\.0-ea\./

    Fetching version info for GraalVM EA builds from 'https://api.github.com/repos/graalvm/oracle-graalvm-ea-builds/contents/versions/24-ea.json?ref=main' failed with the error: API rate limit exceeded for 13.105.117.111. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)

      146 |         .result;
      147 |     } catch (err) {
    > 148 |       throw Error(
          |             ^
      149 |         `Fetching version info for GraalVM EA builds from '${url}' failed with the error: ${
      150 |           (err as Error).message
      151 |         }`

      at GraalVMDistribution.<anonymous> (src/distributions/graalvm/installer.ts:148:13)
          at Generator.throw (<anonymous>)
      at rejected (src/distributions/graalvm/installer.ts:29:65)
```

Adding the `GITHUB_TOKEN` would allow repositories that use this reusable workflow (such as actions/setup-java) to pass more reliably... https://github.com/check-spelling-sandbox/setup-java/pull/2