### PR TITLE
Upgrade to use node24

### DIFF
--- a/.github/workflows/basic-validation.yml
+++ b/.github/workflows/basic-validation.yml
@@ -24,7 +24,7 @@ on:
         description: "Optional input to set the version of Node.js used to build the project. The input syntax corresponds to the setup-node's one"
         required: false
         type: string
-        default: "20.x"
+        default: "24.x"
       node-caching:
         description: "Optional input to set up caching for the setup-node action. The input syntax corresponds to the setup-node's one. Set to an empty string if caching isn't needed"
         required: false

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -16,7 +16,7 @@ on:
         description: "Optional input to set the version of Node.js used to build a project. The input syntax corresponds to the setup-node's one"
         required: false
         type: string
-        default: "20.x"
+        default: "24.x"
       node-caching:
         description: "Optional input to set up caching for the setup-node action. The input syntax corresponds to the setup-node's one. Set to an empty string if caching isn't needed"
         required: false

--- a/.github/workflows/update-config-files.yml
+++ b/.github/workflows/update-config-files.yml
@@ -86,7 +86,7 @@ jobs:
         if: ${{ steps.successful-update.outputs.STATUS == 'true' }}
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install dependencies
         if: ${{ steps.successful-update.outputs.STATUS == 'true' }}


### PR DESCRIPTION
This pull request updates the Node.js version used across multiple GitHub Actions workflows from version `20.x` to `24.x`. This ensures consistency and alignment with the latest Node.js version for building and testing the project.