### PR TITLE
Update Licensed tool version and setup process

### DIFF
--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -19,9 +19,9 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@6e5d382445ae5590b7449d8b3bc8cb1c2c27f617 # v1.317.0
+        uses: ruby/setup-ruby@003a5c4d8d6321bd302e38f6f0ec593f77f06600 # v1.319.0
         with:
-          ruby-version: '3.1.7'
+          ruby-version: '3.4'
 
       - name: Install licensed tool
         run: |

--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -26,13 +26,12 @@ jobs:
       - name: Install licensed tool
         run: |
           cd "$RUNNER_TEMP"
-          curl -Lfs -o licensed.tar.gz https://github.com/licensee/licensed/archive/refs/tags/v5.0.4.tar.gz
+          curl -Lfs -o licensed.tar.gz https://github.com/licensee/licensed/archive/refs/tags/v5.1.0.tar.gz
           tar -xzf licensed.tar.gz
-          cd licensed-5.0.4
+          cd licensed-5.1.0
           bundle install
 
       - name: Check cached dependency records
         run: |
           cd ${{ github.workspace }}
-          BUNDLE_GEMFILE=$RUNNER_TEMP/licensed-5.0.4/Gemfile bundle exec $RUNNER_TEMP/licensed-5.0.4/exe/licensed status
-          
+          BUNDLE_GEMFILE=$RUNNER_TEMP/licensed-5.1.0/Gemfile bundle exec $RUNNER_TEMP/licensed-5.1.0/exe/licensed status

--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -1,5 +1,5 @@
 # This workflow helps to check the statuses of cached dependencies used in action with the help of the Licensed tool.
-# Learn more about Licensed at https://github.com/github/licensed
+# Learn more about Licensed at https://github.com/licensee/licensed
 
 name: Licensed
 
@@ -18,12 +18,20 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1.7'
+
       - name: Install licensed tool
         run: |
           cd "$RUNNER_TEMP"
-          curl -Lfs -o licensed.tar.gz https://github.com/github/licensed/releases/download/3.9.0/licensed-3.9.0-linux-x64.tar.gz 
-          sudo tar -xzf licensed.tar.gz
-          sudo mv licensed /usr/local/bin/licensed
+          curl -Lfs -o licensed.tar.gz https://github.com/licensee/licensed/archive/refs/tags/v5.0.4.tar.gz
+          tar -xzf licensed.tar.gz
+          cd licensed-5.0.4
+          bundle install
 
       - name: Check cached dependency records
-        run: licensed status
+        run: |
+          cd ${{ github.workspace }}
+          BUNDLE_GEMFILE=$RUNNER_TEMP/licensed-5.0.4/Gemfile bundle exec $RUNNER_TEMP/licensed-5.0.4/exe/licensed status

--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -19,7 +19,7 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@6e5d382445ae5590b7449d8b3bc8cb1c2c27f617 # v1.317.0
         with:
           ruby-version: '3.1.7'
 
@@ -35,3 +35,4 @@ jobs:
         run: |
           cd ${{ github.workspace }}
           BUNDLE_GEMFILE=$RUNNER_TEMP/licensed-5.0.4/Gemfile bundle exec $RUNNER_TEMP/licensed-5.0.4/exe/licensed status
+          


### PR DESCRIPTION
**PR Description:**
Updates the licensed tool from `github/licensed` v3.9.0 (pre-built binary) to `licensee/licensed` v5.1.0 (source install via Ruby/Bundler).

**Changes:**
- Added Ruby setup step
- Switched download URL from `github/licensed` to `licensee/licensed`
- Updated install and invocation to use Bundler since v5.x no longer ships pre-built binaries